### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 06:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- Add missing CodeQL analysis workflow for JavaScript/TypeScript scanning
- Runs on push to main, on PRs targeting main, and weekly (Monday 06:00 UTC)
- Uses `github/codeql-action` v3 with `actions/checkout` v4

## Context

The repository has CodeQL scanning configured as a required check in branch protection, but the actual workflow file was missing. This caused all PRs (including Dependabot PRs) to fail with:

> Code scanning results / CodeQL — 2 configurations not found

This PR adds the workflow so the required check can pass.

## Test plan

- [ ] Verify the CodeQL workflow runs successfully on this PR
- [ ] Confirm Dependabot PRs no longer show "configurations not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)