### PR TITLE
ci(merge-queue): fix git identity, label race, and add run links

### DIFF
--- a/.github/scripts/merge-queue.sh
+++ b/.github/scripts/merge-queue.sh
@@ -5,6 +5,10 @@ REPO="$GITHUB_REPOSITORY"
 MAIN_BRANCH="main"
 TEMP_BRANCH="merge-queue/validation"
 
+# Configure git identity for merge commits on the runner
+git config user.name "merge-queue[bot]"
+git config user.email "merge-queue[bot]@users.noreply.github.com"
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 log()  { echo "::group::$1"; }
@@ -108,7 +112,7 @@ while true; do
     # Try to merge into temp branch
     if ! git merge --no-ff "origin/$PR_BRANCH" -m "merge-queue: validate PR #$pr ($PR_BRANCH)"; then
       echo "::error::Merge conflict for PR #$pr"
-      git merge --abort
+      git merge --abort 2>/dev/null || true
 
       remove_from_queue "$pr"
       comment_pr "$pr" "$(cat <<EOF
@@ -122,6 +126,7 @@ Please rebase your branch on \`$MAIN_BRANCH\` and re-add with \`/merge\`.
 
 Position: $((${#VALIDATED[@]} + 1)) of ${#QUEUE[@]}
 PRs ahead: ${VALIDATED[*]:-none}
+[View CI run]($MERGE_QUEUE_RUN_URL)
 </details>
 EOF
 )"
@@ -150,6 +155,7 @@ Please fix the issue and re-add with \`/merge\`.
 
 Position: $((${#VALIDATED[@]} + 1)) of ${#QUEUE[@]}
 PRs ahead: ${VALIDATED[*]:-none}
+[View CI run]($MERGE_QUEUE_RUN_URL)
 </details>
 EOF
 )"
@@ -197,7 +203,7 @@ EOF
 
     if gh pr merge "$pr" --merge --repo "$REPO"; then
       echo "✅ PR #$pr merged successfully"
-      comment_pr "$pr" "✅ **Merge queue: merged** — All checks passed. PR has been merged into \`$MAIN_BRANCH\`."
+      comment_pr "$pr" "✅ **Merge queue: merged** — All checks passed. PR has been merged into \`$MAIN_BRANCH\`. [View CI run]($MERGE_QUEUE_RUN_URL)"
       remove_from_queue "$pr"
     else
       echo "::error::Failed to merge PR #$pr via GitHub API"

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -60,14 +60,17 @@ jobs:
         if: steps.command.outputs.action == 'enqueue'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           PR=${{ github.event.issue.number }}
           # Ensure the label exists (create if needed)
           gh label create merge-queue --color "3CB371" --description "PR is in the merge queue" \
             --repo ${{ github.repository }} 2>/dev/null || true
           gh pr edit $PR --add-label merge-queue --repo ${{ github.repository }}
-          gh pr comment $PR --body "🚀 Added to merge queue. Processing will begin shortly." \
+          gh pr comment $PR --body "🚀 Added to merge queue. Processing will begin shortly. [Follow progress]($RUN_URL)" \
             --repo ${{ github.repository }}
+          # Give GitHub time to index the label before querying
+          sleep 5
 
       # --- Process queue ---
       - name: Checkout repository
@@ -89,4 +92,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          MERGE_QUEUE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash .github/scripts/merge-queue.sh


### PR DESCRIPTION
## Summary
- Fix missing git `user.name`/`user.email` on the runner causing `git merge --no-ff` to fail with "Committer identity unknown"
- Add 5s sleep after label application to avoid race condition where `gh pr list --label merge-queue` returns empty because GitHub hasn't indexed the label yet
- Guard `git merge --abort` with `|| true` so it doesn't cascade-fail via `set -e` when no merge was in progress
- Add workflow run URL links to all merge queue PR comments ("Added to queue", "Removed", "Merged")

## Root cause analysis
[Run 22546793828](https://github.com/Serraniel/Sweetfolio/actions/runs/22546793828) failed because the GitHub Actions runner has no git identity configured. The `git merge --no-ff` command requires a committer name/email to create merge commits. When that failed, `git merge --abort` also failed (no merge to abort), and `set -euo pipefail` killed the script.

[Run 22546789511](https://github.com/Serraniel/Sweetfolio/actions/runs/22546789511) succeeded but did nothing — it found an empty queue because the label query executed before GitHub indexed the just-added label.

## Test plan
- [ ] Re-test with the two dummy PRs (#18, #19) — both should be processed and merged
- [ ] Verify "Added to merge queue" comment includes a clickable link to the workflow run
- [ ] Verify failure comments include CI run link

Generated with [Claude Code](https://claude.com/claude-code)