### PR TITLE
ci(merge-queue): bypass branch protection with --admin flag

### DIFF
--- a/.github/scripts/merge-queue.sh
+++ b/.github/scripts/merge-queue.sh
@@ -220,7 +220,7 @@ EOF
   for pr in "${VALIDATED[@]}"; do
     log "Merging PR #$pr"
 
-    if gh pr merge "$pr" --merge --repo "$REPO"; then
+    if gh pr merge "$pr" --merge --admin --repo "$REPO"; then
       echo "✅ PR #$pr merged successfully"
       comment_pr "$pr" "✅ **Merge queue: merged** — All checks passed. PR has been merged into \`$MAIN_BRANCH\`. [View CI run]($MERGE_QUEUE_RUN_URL)"
       remove_from_queue "$pr"


### PR DESCRIPTION
## Summary
- Add `--admin` flag to `gh pr merge` so the merge queue can bypass the "branch must be up to date" branch protection rule
- The merge queue already validates PRs by speculatively merging them on a temp branch and running the full CI pipeline, so bypassing the up-to-date requirement is safe

## Test plan
- [ ] Comment `/merge` on a test PR that is behind `main`
- [ ] Verify it passes validation and merges successfully

Generated with [Claude Code](https://claude.com/claude-code)