### PR TITLE
feat(nav): reorder navigation and nest Compare under Assets

### DIFF
--- a/src/lib/components/layout/Nav.svelte
+++ b/src/lib/components/layout/Nav.svelte
@@ -7,14 +7,17 @@
 		href: string;
 		label: string;
 		icon: string;
+		children?: NavItem[];
 	}
 
 	const navItems: NavItem[] = [
 		{ href: '/', label: 'Dashboard', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1' },
-		{ href: '/assets', label: 'Assets', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z' },
-		{ href: '/compare', label: 'Compare', icon: 'M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5' },
-		{ href: '/portfolios', label: 'Portfolios', icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10' },
+		{ href: '/assets', label: 'Assets', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', children: [
+			{ href: '/compare', label: 'Compare', icon: 'M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5' }
+		] },
 		{ href: '/simulation', label: 'Simulation', icon: 'M13 10V3L4 14h7v7l9-11h-7z' },
+		{ href: '/portfolios', label: 'Portfolios', icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10' },
+		{ href: '/strategies', label: 'Strategies', icon: 'M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
 		{ href: '/settings', label: 'Settings', icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' }
 	];
 
@@ -56,6 +59,25 @@
 						<span class="nav-label">{item.label}</span>
 					{/if}
 				</a>
+				{#if item.children && !collapsed}
+					<ul class="nav-children">
+						{#each item.children as child}
+							<li>
+								<a
+									href={child.href}
+									class="nav-link nav-child-link"
+									class:active={isActive(child.href)}
+									title={child.label}
+								>
+									<svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+										<path d={child.icon}/>
+									</svg>
+									<span class="nav-label">{child.label}</span>
+								</a>
+							</li>
+						{/each}
+					</ul>
+				{/if}
 			</li>
 		{/each}
 	</ul>
@@ -176,6 +198,16 @@
 	.nav-label {
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	.nav-children {
+		list-style: none;
+		padding-left: var(--spacing-lg);
+	}
+
+	.nav-child-link {
+		font-size: var(--font-size-xs);
+		padding: var(--spacing-xs) var(--spacing-md);
 	}
 
 	.nav-footer {


### PR DESCRIPTION
## Summary
- Reorder main navigation to: Dashboard → Assets → Simulation → Portfolios → Strategies → Settings
- Add sub-navigation support with nested items rendered as indented child links
- Move Compare as a child entry under Assets (Compare only operates on assets)

## Test plan
- [x] Build passes (`vite build`)
- [x] All 327 unit tests pass (`vitest run`)
- [ ] Verify nav order visually in browser
- [ ] Verify Compare appears nested under Assets when sidebar is expanded
- [ ] Verify Compare is hidden when sidebar is collapsed (sub-items only show when expanded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)