### PR TITLE
ci: daily dependabot checks with auto-merge for non-major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,19 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr review "$PR_NUMBER" --approve --repo "$REPO"
+
+      - name: Add to merge queue
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create merge-queue --color "3CB371" --description "PR is in the merge queue" \
+            --repo "$REPO" 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --add-label merge-queue --repo "$REPO"
+          gh pr comment "$PR_NUMBER" --body "🤖 **Auto-merge**: Non-major dependabot update — approved and added to merge queue." \
+            --repo "$REPO"


### PR DESCRIPTION
## Summary
- Changes dependabot schedule from weekly to **daily** for both `npm` and `github-actions` ecosystems
- Groups minor and patch updates together to reduce PR noise
- Adds a new `dependabot-auto-merge.yml` workflow that automatically **approves** and **enqueues** non-major dependabot PRs into the existing merge queue

## How it works
1. Dependabot opens a PR (runs daily now)
2. The new workflow detects `dependabot[bot]` as the actor
3. It fetches semver metadata via `dependabot/fetch-metadata`
4. For non-major updates: auto-approves the PR and adds the `merge-queue` label
5. The existing merge queue workflow picks it up and processes it

Major version bumps are left for manual review.

## Test plan
- [ ] Verify dependabot creates daily PRs after merge
- [ ] Verify non-major dependabot PRs get auto-approved and labeled `merge-queue`
- [ ] Verify major version bumps are NOT auto-merged
- [ ] Verify the merge queue processes the labeled PRs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)