### PR TITLE
ci(release): switch from per-merge to daily scheduled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -19,9 +19,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Wait for batching window
-        run: sleep 300
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Replace push-on-main trigger with a daily cron schedule (midnight UTC)
- Remove the 5-minute batching sleep (daily schedule handles batching naturally)
- Keep `workflow_dispatch` for manual releases

Semantic-release still determines whether a version bump is needed — on days with no releasable commits, it exits cleanly and no Docker build is triggered.

## Test plan
- [ ] Verify workflow syntax is valid via GitHub Actions UI
- [ ] Trigger a manual run via `workflow_dispatch` to confirm it still works
- [ ] Confirm no release is created when there are no releasable commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)