### PR TITLE
fix: resolve version 0.0.0 in npm dev by reading git tags

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,27 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 const envVersion = process.env.APP_VERSION?.replace(/^v/, '');
 
+function getGitTagVersion(): string | undefined {
+	try {
+		return execFileSync('git', ['describe', '--tags', '--abbrev=0'], { encoding: 'utf-8' })
+			.trim()
+			.replace(/^v/, '');
+	} catch {
+		return undefined;
+	}
+}
+
+const appVersion = envVersion || getGitTagVersion() || pkg.version;
+
 export default defineConfig({
 	plugins: [sveltekit()],
 	define: {
-		__APP_VERSION__: JSON.stringify(envVersion || pkg.version)
+		__APP_VERSION__: JSON.stringify(appVersion)
 	},
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']


### PR DESCRIPTION
## Summary
- **Version 0.0.0 fix for local dev**: Vite config now uses `git describe --tags --abbrev=0` as a fallback when `APP_VERSION` env var is not set
- Version resolution priority: `APP_VERSION` env var > git tag > `package.json` version
- Uses `execFileSync` (no shell) for safety; silently falls back if no git tags exist

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 327 unit tests pass (`npm test`)
- [x] Verified version `0.3.1` appears in build output instead of `0.0.0`
- [ ] Run `npm run dev` and confirm footer shows correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)