### PR TITLE
fix(charts): prevent range init from overriding user 'all' selection

### DIFF
--- a/src/lib/charts/PriceChart.svelte
+++ b/src/lib/charts/PriceChart.svelte
@@ -38,6 +38,7 @@
 	let themeObs: MutationObserver | undefined;
 	let logScale: boolean = $state(false);
 	let selectedRange: TimeRange = $state('all');
+	let rangeInitialized = false;
 
 	// Default: relative when multi-series, absolute when single
 	let viewMode: ViewMode = $state('absolute');
@@ -48,13 +49,16 @@
 	$effect(() => {
 		viewMode = initialMode ?? (isMultiSeries ? 'relative' : 'absolute');
 	});
-	// Set default range when series data becomes available.
+	// Set default range once when series data becomes available.
 	// Prefers explicit prop, then 'max' (multi-series overlap), then 'all'.
 	$effect(() => {
+		if (rangeInitialized) return;
 		if (initialRange) {
 			selectedRange = initialRange;
-		} else if (maxRange && selectedRange === 'all') {
+			rangeInitialized = true;
+		} else if (maxRange) {
 			selectedRange = 'max';
+			rangeInitialized = true;
 		}
 	});
 


### PR DESCRIPTION
## Summary
- Fixes a bug where clicking "ALL" in the price chart time range buttons had no effect when "MAX" was active (multi-series/comparison view)
- The `$effect` that initializes the default range to "max" for multi-series charts was re-triggering on every user click of "ALL", because `selectedRange === 'all'` matched both the uninitialized state and the user's intentional selection
- Added an initialization flag so the effect only fires once, allowing users to freely switch between all time ranges

## Test plan
- [ ] Open comparison view with multiple assets
- [ ] Verify chart defaults to "MAX" range
- [ ] Click "ALL" — chart should switch to show all data, and "ALL" button should be highlighted (not "MAX")
- [ ] Click other ranges (1Y, 3Y, etc.) and back to "ALL" — all should work
- [ ] Verify single-asset view still defaults to "ALL" and works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)