### PR TITLE
fix(compare): use asset slugs instead of GUIDs in compare URLs

### DIFF
--- a/e2e/compare-screenshots.spec.ts
+++ b/e2e/compare-screenshots.spec.ts
@@ -170,7 +170,7 @@ test.describe('Comparison Feature — Visual Demo', () => {
 		// ── Step 3: Click "Compare 2 Assets" button ──
 		const compareBtn = page.getByRole('button', { name: /Compare 2 Assets/ });
 		await compareBtn.click();
-		await expect(page).toHaveURL(/\/compare\?ids=/);
+		await expect(page).toHaveURL(/\/compare\?slugs=/);
 
 		// Wait for metrics to load
 		await page.waitForSelector('.comparison-table');

--- a/e2e/compare.spec.ts
+++ b/e2e/compare.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { slugify } from '../src/lib/utils/slug';
 
 /**
  * E2E tests for the Asset Comparison feature.
@@ -165,7 +166,7 @@ test.describe('Asset Comparison Feature', () => {
 			await expect(compareBtn).toBeVisible();
 		});
 
-		test('navigates to compare page with selected asset IDs', async ({ page }) => {
+		test('navigates to compare page with selected asset slugs', async ({ page }) => {
 			await page.goto('/assets');
 			await page.waitForSelector('.asset-table');
 
@@ -176,13 +177,13 @@ test.describe('Asset Comparison Feature', () => {
 			const compareBtn = page.getByRole('button', { name: /Compare 2 Assets/ });
 			await compareBtn.click();
 
-			await expect(page).toHaveURL(/\/compare\?ids=/);
+			await expect(page).toHaveURL(/\/compare\?slugs=/);
 		});
 	});
 
 	test.describe('Compare page', () => {
 		test('displays selected assets as chips', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 			await page.waitForSelector('.asset-chip');
 
 			const chips = page.locator('.asset-chip');
@@ -192,7 +193,7 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('shows financial metrics comparison table', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 			await page.waitForSelector('.comparison-table');
 
 			const table = page.locator('.comparison-table').first();
@@ -207,7 +208,7 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('shows period selector tabs', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 			await page.waitForSelector('.period-tabs');
 
 			const tabs = page.locator('.period-tab');
@@ -215,7 +216,7 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('switching period tabs updates metrics', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 			await page.waitForSelector('.period-tabs');
 
 			// Click "1Y" period tab
@@ -224,13 +225,13 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('shows price history chart section', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 
 			await expect(page.locator('text=Price History')).toBeVisible();
 		});
 
 		test('shows drawdown section', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 
 			await expect(page.locator('text=Drawdowns')).toBeVisible();
 			// Should have one drawdown card per asset
@@ -239,7 +240,7 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('shows asset details comparison table', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 
 			await expect(page.locator('text=Asset Details')).toBeVisible();
 
@@ -251,7 +252,7 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('can remove an asset from comparison', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 			await page.waitForSelector('.asset-chip');
 
 			await expect(page.locator('.asset-chip')).toHaveCount(2);
@@ -262,11 +263,11 @@ test.describe('Asset Comparison Feature', () => {
 
 			await expect(page.locator('.asset-chip')).toHaveCount(1);
 			// URL should update
-			await expect(page).toHaveURL(/\/compare\?ids=/);
+			await expect(page).toHaveURL(/\/compare\?slugs=/);
 		});
 
 		test('can add an asset to comparison from dropdown', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id},${TEST_ASSETS[1].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)},${slugify(TEST_ASSETS[1].name)}`);
 			await page.waitForSelector('.add-asset-select');
 
 			// The third asset should be available in the dropdown
@@ -284,7 +285,7 @@ test.describe('Asset Comparison Feature', () => {
 		});
 
 		test('shows prompt to add more when only 1 asset selected', async ({ page }) => {
-			await page.goto(`/compare?ids=${TEST_ASSETS[0].id}`);
+			await page.goto(`/compare?slugs=${slugify(TEST_ASSETS[0].name)}`);
 			await expect(page.locator('.empty-state')).toBeVisible();
 			await expect(page.locator('.empty-state')).toContainText('Add at least one more');
 		});

--- a/src/lib/charts/CorrelationMatrix.svelte
+++ b/src/lib/charts/CorrelationMatrix.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { CorrelationMatrix } from '$lib/types';
 	import { COLORS, isDarkTheme, observeThemeChanges } from './utils';
+	import { slugify } from '$lib/utils/slug';
 	import { goto } from '$app/navigation';
 
 	interface Props {
@@ -16,8 +17,8 @@
 
 	function handleCellClick(row: number, col: number) {
 		if (row === col) return;
-		const ids = [data.assetIds[row], data.assetIds[col]].join(',');
-		goto(`/compare?ids=${encodeURIComponent(ids)}`);
+		const slugs = [slugify(labels[row]), slugify(labels[col])].join(',');
+		goto(`/compare?slugs=${encodeURIComponent(slugs)}`);
 	}
 
 	function correlationColor(val: number): string {

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -35,8 +35,14 @@
 
 	function goToCompare() {
 		if (selectedForCompare.size < 2) return;
-		const ids = Array.from(selectedForCompare).join(',');
-		goto(`/compare?ids=${encodeURIComponent(ids)}`);
+		const slugs = Array.from(selectedForCompare)
+			.map((id) => {
+				const asset = $assets.find((a) => a.id === id);
+				return asset ? slugify(asset.name) : '';
+			})
+			.filter((s) => s.length > 0)
+			.join(',');
+		goto(`/compare?slugs=${encodeURIComponent(slugs)}`);
 	}
 
 	function isBenchmark(assetId: string): boolean {

--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -18,41 +18,42 @@
 		bestInRow as findBestInRow
 	} from '$lib/utils/comparison';
 	import type { Asset, MetricsResult, PeriodKey, CurrencyRate } from '$lib/types';
+	import { slugify } from '$lib/utils/slug';
 
-	// Parse asset IDs from URL query params
-	const compareIds = $derived.by(() => {
-		const raw = page.url.searchParams.get('ids') ?? '';
-		return raw.split(',').filter((id) => id.length > 0);
+	// Parse asset slugs from URL query params
+	const compareSlugs = $derived.by(() => {
+		const raw = page.url.searchParams.get('slugs') ?? '';
+		return raw.split(',').filter((s) => s.length > 0);
 	});
 
 	// Resolve to actual assets
 	const compareAssets = $derived(
-		compareIds
-			.map((id) => $assets.find((a) => a.id === id))
+		compareSlugs
+			.map((slug) => $assets.find((a) => slugify(a.name) === slug))
 			.filter((a): a is Asset => a !== undefined)
 	);
 
 	// Assets available to add (not already in comparison)
 	const availableAssets = $derived(
-		$assets.filter((a) => !compareIds.includes(a.id))
+		$assets.filter((a) => !compareSlugs.includes(slugify(a.name)))
 	);
 
 	// Update URL when assets change
-	function updateUrl(ids: string[]) {
+	function updateUrl(slugs: string[]) {
 		const params = new URLSearchParams();
-		if (ids.length > 0) params.set('ids', ids.join(','));
+		if (slugs.length > 0) params.set('slugs', slugs.join(','));
 		goto(`/compare?${params.toString()}`, { replaceState: true, keepFocus: true });
 	}
 
-	function removeFromComparison(assetId: string) {
-		updateUrl(compareIds.filter((id) => id !== assetId));
+	function removeFromComparison(assetSlug: string) {
+		updateUrl(compareSlugs.filter((s) => s !== assetSlug));
 	}
 
-	let addAssetId = $state('');
+	let addAssetSlug = $state('');
 	function addToComparison() {
-		if (!addAssetId) return;
-		updateUrl([...compareIds, addAssetId]);
-		addAssetId = '';
+		if (!addAssetSlug) return;
+		updateUrl([...compareSlugs, addAssetSlug]);
+		addAssetSlug = '';
 	}
 
 	// Build chart series for PriceChart
@@ -183,13 +184,13 @@
 				<h3>Selected Assets ({compareAssets.length})</h3>
 				{#if availableAssets.length > 0}
 					<div class="add-asset-row">
-						<select class="add-asset-select" bind:value={addAssetId}>
+						<select class="add-asset-select" bind:value={addAssetSlug}>
 							<option value="">Add an asset...</option>
 							{#each availableAssets as a}
-								<option value={a.id}>{a.name}</option>
+								<option value={slugify(a.name)}>{a.name}</option>
 							{/each}
 						</select>
-						<Button variant="primary" size="sm" disabled={!addAssetId} onclick={addToComparison}>
+						<Button variant="primary" size="sm" disabled={!addAssetSlug} onclick={addToComparison}>
 							Add
 						</Button>
 					</div>
@@ -207,7 +208,7 @@
 							<span class="chip-meta">{asset.currency}</span>
 							<button
 								class="chip-remove"
-								onclick={() => removeFromComparison(asset.id)}
+								onclick={() => removeFromComparison(slugify(asset.name))}
 								aria-label="Remove {asset.name} from comparison"
 							>
 								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Summary
- Replace internal asset GUIDs with human-readable slugified asset names in compare page URLs
- Changes `?ids=abc-123,def-456` to `?slugs=test-stock-alpha,test-etf-beta`
- Updated all three entry points: assets page selection, compare page dropdown, and correlation matrix click-to-compare

## Test plan
- [x] Build passes
- [x] All 327 unit tests pass
- [x] All 18 compare E2E tests pass
- [ ] Manual: select assets on /assets and verify /compare URL uses slugs
- [ ] Manual: click correlation matrix cell and verify slug-based URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)