### PR TITLE
fix(simulation): align MC time periods and use hybrid return estimation

### DIFF
--- a/src/lib/workers/montecarlo.worker.ts
+++ b/src/lib/workers/montecarlo.worker.ts
@@ -55,16 +55,18 @@ function runSimulation(
     efficientFrontier: [],
   };
 
-  // Align and compute log returns for all assets
-  const { alignedSeries } = alignPriceSeries(assets.map((a) => a.prices));
-  const assetReturns = alignedSeries.map((prices) => logReturns(prices));
-
-  // Pre-compute per-asset annualized stats
-  const assetMeans = assetReturns.map((r) => mean(r) * TRADING_DAYS_PER_YEAR);
+  // Per-asset expected returns use each asset's FULL individual history.
+  // This gives a better estimate since the mean only depends on one series.
+  // (Hybrid approach per Stambaugh 1997 / practitioner convention.)
+  const fullReturns = assets.map((a) => logReturns(a.prices.map((p) => p.close)));
+  const assetMeans = fullReturns.map((r) => mean(r) * TRADING_DAYS_PER_YEAR);
   const assetIds = assets.map((a) => a.id);
 
-  // Pre-compute covariance matrix for portfolio volatility
-  const covMatrix = computeCovarianceMatrix(assetReturns);
+  // Covariance matrix requires synchronized (contemporaneous) observations,
+  // so we align all series to their common date intersection.
+  const { alignedSeries } = alignPriceSeries(assets.map((a) => a.prices));
+  const alignedReturns = alignedSeries.map((prices) => logReturns(prices));
+  const covMatrix = computeCovarianceMatrix(alignedReturns);
 
   // Pre-allocate typed arrays at max capacity; trim after deduplication
   const volArr = new Float64Array(simulationCount);

--- a/src/routes/simulation/+page.svelte
+++ b/src/routes/simulation/+page.svelte
@@ -12,6 +12,8 @@
 	import { annualizedLogReturn } from '$lib/engine/returns';
 	import { annualizedVolatility } from '$lib/engine/volatility';
 	import { convertPrices } from '$lib/engine/currency';
+	import { alignPriceSeries } from '$lib/utils/dates';
+	import { logReturns, stddev } from '$lib/utils/math';
 	import { generateAssetColors } from '$lib/charts/utils';
 	import type { AssetMarker } from '$lib/charts/EfficientFrontier.svelte';
 	import type { MonteCarloWorkerRequest, MonteCarloWorkerResponse, SimulatedPortfolio, CurrencyRate, PricePoint } from '$lib/types';
@@ -103,12 +105,15 @@
 		};
 	});
 
-	// Compute per-asset markers using the same log-return-based metrics as the MC worker.
-	// Colors match the sidebar dots by using each asset's index in the full assetSelections list.
-	// Prices are converted to main currency for consistent comparison.
+	// Compute per-asset markers matching the MC worker's hybrid approach:
+	// - Expected return: full individual history (better estimate, more data)
+	// - Volatility: aligned (intersection) window (consistent with portfolio covariance)
+	const TRADING_DAYS_PER_YEAR = 252;
 	const assetMarkerList = $derived.by((): AssetMarker[] => {
 		if (!result) return [];
-		const markers: AssetMarker[] = [];
+
+		// Collect selected assets with converted prices (same as handleRun sends to worker)
+		const selected: Array<{ idx: number; name: string; prices: PricePoint[] }> = [];
 		for (let i = 0; i < assetSelections.length; i++) {
 			const sel = assetSelections[i];
 			if (!sel.selected) continue;
@@ -116,11 +121,34 @@
 			if (!asset || asset.prices.length < 2) continue;
 			const prices = convertAssetPrices(asset.currency, asset.prices) ?? asset.prices;
 			if (prices.length < 2) continue;
+			selected.push({ idx: i, name: asset.name, prices });
+		}
+
+		if (selected.length < 2) {
+			return selected.map((s) => ({
+				name: s.name,
+				annualizedReturn: annualizedLogReturn(s.prices),
+				volatility: annualizedVolatility(s.prices),
+				color: assetColors[s.idx],
+			}));
+		}
+
+		// Volatility uses the aligned intersection (same as MC covariance matrix)
+		const { alignedSeries } = alignPriceSeries(selected.map((s) => s.prices));
+
+		const markers: AssetMarker[] = [];
+		for (let i = 0; i < selected.length; i++) {
+			// Return from full individual history (same as MC worker)
+			const annReturn = annualizedLogReturn(selected[i].prices);
+			// Volatility from aligned window (consistent with MC covariance)
+			const alignedRet = logReturns(alignedSeries[i]);
+			if (alignedRet.length < 2) continue;
+			const annVol = stddev(alignedRet) * Math.sqrt(TRADING_DAYS_PER_YEAR);
 			markers.push({
-				name: asset.name,
-				annualizedReturn: annualizedLogReturn(prices),
-				volatility: annualizedVolatility(prices),
-				color: assetColors[i],
+				name: selected[i].name,
+				annualizedReturn: annReturn,
+				volatility: annVol,
+				color: assetColors[selected[i].idx],
 			});
 		}
 		return markers;


### PR DESCRIPTION
## Summary
- Fixed time-period mismatch between Monte Carlo portfolio simulation and individual asset markers on the efficient frontier chart
- MC worker now uses hybrid approach: full individual history for expected returns, aligned intersection for covariance matrix (per Stambaugh 1997 / practitioner convention)
- Asset markers match the same methodology so dots are visually consistent with the portfolio scatter cloud

## Problem
The MC worker aligned all asset prices to their common date intersection before computing returns, but asset markers used each asset's full individual history. When assets had different history lengths (e.g., 2 years vs 20 years), portfolios appeared to have higher returns than any individual asset — a mathematical impossibility for weighted averages.

## Test plan
- [ ] Run Monte Carlo simulation with assets of varying history lengths
- [ ] Verify no portfolio dot exceeds the highest individual asset return
- [ ] Verify asset marker positions are consistent with the portfolio scatter cloud
- [ ] Unit tests pass (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)