### PR TITLE
fix(changelog): parse patch version headings

### DIFF
--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -61,7 +61,7 @@
 			null;
 
 		for (const line of lines) {
-			const versionMatch = line.match(/^# \[(\d+\.\d+\.\d+[^\]]*)\].*\((\d{4}-\d{2}-\d{2})\)/);
+			const versionMatch = line.match(/^#{1,2} \[(\d+\.\d+\.\d+[^\]]*)\].*\((\d{4}-\d{2}-\d{2})\)/);
 			if (versionMatch) {
 				if (currentSection) {
 					sections.push({


### PR DESCRIPTION
## Summary
- Patch releases (e.g. 0.5.1, 0.3.1) use `##` headings in the CHANGELOG while minor/major releases use `#`. The version parser regex only matched `#`, so patch versions were missing from the changelog page.
- Fixes the regex to match both `#` and `##` version headings (`^#{1,2} \[...`)

## Test plan
- [ ] Deploy and verify that 0.5.1 and 0.3.1 appear in the changelog page
- [ ] Verify that all other versions still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)