### PR TITLE
feat: AI-friendly export format + local MCP server

### DIFF
--- a/docs/plans/2026-03-07-parqet-connect-design.md
+++ b/docs/plans/2026-03-07-parqet-connect-design.md
@@ -1,0 +1,103 @@
+# Parqet Connect Integration Design
+
+## Overview
+Integrate Sweetfolio with Parqet Connect API to enable bidirectional sync between local portfolios and Parqet cloud portfolios.
+
+## Features
+
+### 1. OAuth2 PKCE Authentication Flow
+- Settings page section for Parqet Connect
+- "Connect to Parqet" button triggers OAuth2 PKCE flow
+- Store tokens in IndexedDB settings (access_token, refresh_token, expires_at)
+- Auto-refresh tokens before expiry
+- Disconnect option to revoke and clear tokens
+
+### 2. Import from Parqet (Pull)
+- Fetch user's Parqet portfolios via GET /portfolios
+- Fetch activities per portfolio via GET /portfolios/{id}/activities (paginated)
+- Fetch performance data via POST /performance
+- Map Parqet data to Sweetfolio types:
+  - Parqet portfolio → Sweetfolio Portfolio (tracked mode)
+  - Parqet activities → Sweetfolio Transactions
+  - Parqet holdings → Sweetfolio Assets (create if missing, match by ISIN)
+- Import wizard step: select which Parqet portfolios to import
+- Conflict resolution with existing data
+
+### 3. Export to Parqet (Push)
+- Push local tracked portfolios to Parqet
+- Create portfolio via POST /portfolios
+- Push transactions as activities via POST /portfolios/{id}/activities (batch 100)
+- Map Sweetfolio transaction types to Parqet activity types
+- Progress indicator for large pushes
+
+### 4. Live Portfolio Dashboard (Parqet Performance Data)
+- Show real-time Parqet performance KPIs alongside local calculations
+- Compare Sweetfolio metrics vs Parqet metrics (XIRR, TTWROR)
+- Display Parqet holdings with logos, quotes, positions
+
+### 5. Sync Status & Management
+- Show connection status in nav/settings
+- Last sync timestamp
+- Per-portfolio sync status (linked to Parqet ID)
+- Manual sync trigger
+
+### 6. Watchlist via Parqet (Creative Feature)
+- User noted Parqet lacks a good watchlist
+- Build a local watchlist feature that uses Parqet's asset data
+- Create "watchlist" portfolios in Parqet with zero-quantity holdings
+- Track performance via the performance endpoint without buying
+
+## Architecture
+
+### New Files
+- `src/lib/parqet/` — Parqet integration module
+  - `oauth.ts` — PKCE flow, token management, refresh
+  - `client.ts` — API client (typed fetch wrapper)
+  - `types.ts` — Parqet API types
+  - `sync.ts` — Bidirectional sync logic
+  - `mapper.ts` — Parqet ↔ Sweetfolio type mapping
+- `src/lib/components/parqet/` — UI components
+  - `ParqetConnectButton.svelte` — OAuth trigger
+  - `ParqetSyncPanel.svelte` — Sync management
+  - `ParqetPortfolioPicker.svelte` — Select portfolios to import
+  - `ParqetPerformanceCard.svelte` — Live performance display
+  - `WatchlistSection.svelte` — Watchlist UI
+- `src/routes/settings/` — Settings page additions
+- `src/routes/watchlist/` — New watchlist page
+
+### Token Storage
+Store in IndexedDB settings store:
+- `parqet_access_token`
+- `parqet_refresh_token`
+- `parqet_token_expires_at`
+- `parqet_client_id` (configurable for user's own app)
+
+### Type Mapping
+
+| Parqet | Sweetfolio |
+|--------|-----------|
+| buy | buy |
+| sell | sell |
+| dividend | dividend |
+| transfer_in | buy (with note) |
+| transfer_out | sell (with note) |
+| interest | dividend (with note) |
+| fees_taxes | (fee field on transactions) |
+| deposit/withdrawal | (cash transactions) |
+
+### OAuth PKCE Flow (browser-only, no server needed)
+1. Generate code_verifier (random 43-128 chars)
+2. Compute code_challenge = base64url(sha256(code_verifier))
+3. Open popup/redirect to authorize URL with client_id, redirect_uri, code_challenge, scope
+4. Receive authorization code at callback
+5. Exchange code + code_verifier for tokens at token URL
+6. Store tokens, set refresh timer
+
+## Implementation Order
+1. OAuth + token management
+2. API client + types
+3. Import from Parqet
+4. Export to Parqet
+5. Performance dashboard
+6. Watchlist feature
+7. Sync management UI

--- a/src/lib/io/ai-export.test.ts
+++ b/src/lib/io/ai-export.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { exportToAIFormat } from './ai-export';
+import type { Asset, Portfolio, Transaction } from '$lib/types';
+
+const asset: Asset = {
+  id: 'a1', name: 'Apple Inc', isin: 'US0378331005', wkn: null,
+  currency: 'USD', classification: 'stock',
+  prices: [{ date: '2024-01-15', close: 182.5 }],
+  formatConfig: null, rawCSV: null, rawCSVStoredAt: null,
+  createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z', lastRefreshedAt: null,
+};
+
+const portfolio: Portfolio = {
+  id: 'p1', name: 'My Portfolio', mode: 'tracked',
+  allocations: [], isBenchmark: false, trackCash: false,
+  cashCurrency: 'EUR', sourceStrategyId: null,
+  createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const tx: Transaction = {
+  id: 'tx1', portfolioId: 'p1', type: 'buy', assetId: 'a1',
+  date: '2024-01-15', quantity: 5, price: 182.5, fee: 1.99,
+  amount: null, withholdingTax: 0, currency: 'USD', notes: '',
+  createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('exportToAIFormat', () => {
+  it('sets format to sweetfolio-ai', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    expect(result.format).toBe('sweetfolio-ai');
+  });
+
+  it('includes a human-readable description', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    expect(typeof result.description).toBe('string');
+    expect(result.description.length).toBeGreaterThan(20);
+  });
+
+  it('includes capabilities array', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    expect(Array.isArray(result.capabilities)).toBe(true);
+    expect(result.capabilities).toContain('read-portfolios');
+  });
+
+  it('includes manifest with type descriptions', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    expect(result.manifest).toBeDefined();
+    expect(result.manifest.types.portfolio).toBeDefined();
+    expect(result.manifest.types.asset).toBeDefined();
+    expect(result.manifest.types.transaction).toBeDefined();
+  });
+
+  it('includes the portfolio data with transactions embedded', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    const pf = result.data.portfolios[0];
+    expect(pf.id).toBe('p1');
+    expect(pf.transactions).toHaveLength(1);
+    expect(pf.transactions[0].type).toBe('buy');
+  });
+
+  it('resolves asset name in transactions', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    const txOut = result.data.portfolios[0].transactions[0];
+    expect((txOut as Record<string, unknown>).assetName).toBe('Apple Inc');
+  });
+
+  it('includes latestPrice and latestPriceDate on assets', () => {
+    const result = exportToAIFormat([portfolio], [asset], [tx]);
+    const a = result.data.assets[0];
+    expect(a.latestPrice).toBe(182.5);
+    expect(a.latestPriceDate).toBe('2024-01-15');
+  });
+});

--- a/src/lib/io/ai-export.ts
+++ b/src/lib/io/ai-export.ts
@@ -1,0 +1,174 @@
+import type { Asset, Portfolio, Transaction } from '$lib/types';
+
+export interface SweetfolioAIExport {
+  format: 'sweetfolio-ai';
+  version: string;
+  exportedAt: string;
+  description: string;
+  capabilities: string[];
+  data: {
+    portfolios: AISweetfolioPortfolio[];
+    assets: AIAssetSummary[];
+  };
+  manifest: {
+    types: Record<string, TypeDescriptor>;
+    currencyNote: string;
+    dateNote: string;
+  };
+}
+
+interface TypeDescriptor {
+  description: string;
+  fields: Record<string, string>;
+}
+
+export interface AISweetfolioPortfolio {
+  id: string;
+  name: string;
+  mode: string;
+  currency: string;
+  transactions: AITransaction[];
+}
+
+export interface AITransaction {
+  id: string;
+  type: string;
+  date: string;
+  assetId: string;
+  assetName: string;
+  assetISIN: string | null;
+  quantity: number | null;
+  price: number | null;
+  fee: number;
+  amount: number | null;
+  withholdingTax: number;
+  currency: string;
+  notes: string;
+}
+
+export interface AIAssetSummary {
+  id: string;
+  name: string;
+  isin: string | null;
+  wkn: string | null;
+  currency: string;
+  classification: string;
+  priceHistory: Array<{ date: string; close: number }>;
+  latestPrice: number | null;
+  latestPriceDate: string | null;
+}
+
+export function exportToAIFormat(
+  portfolios: Portfolio[],
+  assets: Asset[],
+  transactions: Transaction[],
+): SweetfolioAIExport {
+  const portfolioIds = new Set(portfolios.map((p) => p.id));
+  const filteredTx = transactions.filter((t) => portfolioIds.has(t.portfolioId));
+  const assetById = new Map(assets.map((a) => [a.id, a]));
+
+  const aiPortfolios: AISweetfolioPortfolio[] = portfolios.map((pf) => {
+    const pfTx = filteredTx.filter((t) => t.portfolioId === pf.id);
+    return {
+      id: pf.id,
+      name: pf.name,
+      mode: pf.mode,
+      currency: pf.cashCurrency,
+      transactions: pfTx.map((t) => {
+        const a = assetById.get(t.assetId);
+        return {
+          id: t.id,
+          type: t.type,
+          date: t.date,
+          assetId: t.assetId,
+          assetName: a?.name ?? t.assetId,
+          assetISIN: a?.isin ?? null,
+          quantity: t.quantity,
+          price: t.price,
+          fee: t.fee,
+          amount: t.amount,
+          withholdingTax: t.withholdingTax,
+          currency: t.currency,
+          notes: t.notes,
+        };
+      }),
+    };
+  });
+
+  const referencedAssetIds = new Set(filteredTx.map((t) => t.assetId));
+  const aiAssets: AIAssetSummary[] = assets
+    .filter((a) => referencedAssetIds.has(a.id))
+    .map((a) => {
+      const sorted = [...a.prices].sort((x, y) => y.date.localeCompare(x.date));
+      return {
+        id: a.id,
+        name: a.name,
+        isin: a.isin,
+        wkn: a.wkn,
+        currency: a.currency,
+        classification: a.classification,
+        priceHistory: a.prices,
+        latestPrice: sorted[0]?.close ?? null,
+        latestPriceDate: sorted[0]?.date ?? null,
+      };
+    });
+
+  return {
+    format: 'sweetfolio-ai',
+    version: '1',
+    exportedAt: new Date().toISOString(),
+    description:
+      'Sweetfolio portfolio data exported for AI agent use. ' +
+      'Contains portfolio metadata, transaction history, and asset price data. ' +
+      `Exported ${aiPortfolios.length} portfolio(s) with ${filteredTx.length} transaction(s) across ${aiAssets.length} asset(s).`,
+    capabilities: [
+      'read-portfolios',
+      'read-transactions',
+      'read-assets',
+      'read-price-history',
+    ],
+    data: {
+      portfolios: aiPortfolios,
+      assets: aiAssets,
+    },
+    manifest: {
+      types: {
+        portfolio: {
+          description: 'A portfolio groups transactions for performance tracking.',
+          fields: {
+            id: 'UUID, unique identifier',
+            name: 'User-defined portfolio name',
+            mode: '"tracked" = real portfolio with transactions; "model" = allocation model; "both" = both',
+            currency: 'Base currency for cash accounting (ISO 4217)',
+            transactions: 'Array of transactions in this portfolio',
+          },
+        },
+        transaction: {
+          description: 'A single buy, sell, or dividend event for one asset.',
+          fields: {
+            type: '"buy" | "sell" | "dividend"',
+            date: 'ISO 8601 date YYYY-MM-DD',
+            quantity: 'Number of shares/units (null for dividends)',
+            price: 'Price per share at time of transaction (null for dividends)',
+            fee: 'Brokerage fee in transaction currency',
+            amount: 'Total dividend amount (null for buy/sell)',
+            withholdingTax: 'Withholding tax deducted from dividend (0 if not applicable)',
+            currency: 'ISO 4217 currency code for this transaction',
+          },
+        },
+        asset: {
+          description: 'A tradable security, ETF, crypto, or other asset.',
+          fields: {
+            isin: 'International Securities Identification Number (12-char, may be null)',
+            wkn: 'German WKN identifier (may be null)',
+            classification: 'One of: stock, etf, etn, etc, fund, bond, certificate, crypto, commodity, unknown',
+            priceHistory: "Array of {date, close} price points in asset's native currency",
+            latestPrice: 'Most recent close price',
+          },
+        },
+      },
+      currencyNote: 'All monetary values are in the currency field of each transaction/asset. No automatic conversion is applied.',
+      dateNote: 'All dates are in ISO 8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ssZ).',
+    },
+  };
+}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -18,6 +18,8 @@
 	import { autoFetchCurrencyRates } from '$lib/stores/currency-auto-fetch';
 	import ExportModal from '$lib/components/io/ExportModal.svelte';
 	import ImportWizard from '$lib/components/io/ImportWizard.svelte';
+	import { exportToAIFormat } from '$lib/io/ai-export';
+	import { transactions } from '$lib/stores/transactions';
 
 	let mainCurrency = $state('EUR');
 	let riskFreeRate = $state(0);
@@ -141,6 +143,17 @@
 	async function handleDeleteCurrency(pair: string) {
 		if (!confirm(`Delete currency pair ${pair}?`)) return;
 		await removeCurrencyRate(pair);
+	}
+
+	async function exportForAI() {
+		const data = exportToAIFormat($portfolios, $assets, $transactions);
+		const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'sweetfolio-ai-export.json';
+		a.click();
+		URL.revokeObjectURL(url);
 	}
 
 	async function handleClearData() {
@@ -550,6 +563,23 @@
 					</div>
 					<div class="setting-control">
 						<Button variant="default" size="sm" onclick={() => showImportWizard = true}>Import Data</Button>
+					</div>
+				</div>
+			</div>
+		</Card>
+
+		<Card>
+			<div class="setting-section">
+				<h2>Export for AI Agents</h2>
+				<p class="section-description">Download a self-describing JSON file optimized for AI agent consumption. Use with the Sweetfolio MCP server or pass directly to an AI assistant.</p>
+
+				<div class="setting-row">
+					<div class="setting-info">
+						<span class="setting-label">AI Export</span>
+						<span class="setting-description">Includes all portfolios, assets, and transactions in a structured format</span>
+					</div>
+					<div class="setting-control">
+						<Button variant="default" size="sm" onclick={exportForAI}>Download AI Export</Button>
 					</div>
 				</div>
 			</div>

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -1,0 +1,62 @@
+# Sweetfolio MCP Server
+
+A local [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes your Sweetfolio portfolio data to AI assistants such as Claude Code.
+
+## Why file-based?
+
+Sweetfolio is a fully client-side application — it runs entirely in the browser with no backend server. This means a live HTTP-based MCP integration is not possible. Instead, you export your data to a `sweetfolio-ai-export.json` file from within the app, and this MCP server reads that file. The AI assistant then has a point-in-time snapshot of your portfolio data to work with.
+
+## Setup
+
+### 1. Install dependencies and build
+
+```sh
+cd tools/mcp-server
+npm install
+npm run build
+```
+
+### 2. Export your data from Sweetfolio
+
+Inside Sweetfolio, use the **AI Export** feature to download a `sweetfolio-ai-export.json` file.
+
+### 3. Run the server manually (optional test)
+
+```sh
+node dist/index.js /path/to/sweetfolio-ai-export.json
+```
+
+The server communicates over stdio and follows the MCP protocol. It is not meant to be run interactively — use it as an MCP server configured in your AI tool.
+
+## Configure in Claude Code
+
+Add the following to your `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "sweetfolio": {
+      "command": "node",
+      "args": [
+        "/path/to/sweetfolio/tools/mcp-server/dist/index.js",
+        "/path/to/sweetfolio-ai-export.json"
+      ]
+    }
+  }
+}
+```
+
+Replace the paths with the actual absolute paths on your machine.
+
+## Available tools
+
+| Tool | Arguments | Description |
+|---|---|---|
+| `get_portfolios` | — | Returns all portfolios with metadata and transaction count (transactions excluded for brevity) |
+| `get_transactions` | `portfolioId: string` | Returns all transactions for the specified portfolio |
+| `get_assets` | — | Returns all assets with metadata and price history count (price history excluded for brevity) |
+| `get_asset_prices` | `assetId: string` | Returns the full price history for the specified asset |
+
+## Refreshing data
+
+Re-export from Sweetfolio whenever you want the AI assistant to see your latest portfolio state. The MCP server reads the file at startup, so restart the server (or the MCP host) after replacing the export file.

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sweetfolio-mcp",
+  "version": "1.0.0",
+  "description": "Local MCP server for Sweetfolio AI export files",
+  "type": "module",
+  "bin": {
+    "sweetfolio-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ── Argument validation ────────────────────────────────────────────────────
+
+const filePath = process.argv[2];
+if (!filePath) {
+  console.error('Error: No export file path provided.');
+  console.error('Usage: node dist/index.js /path/to/sweetfolio-ai-export.json');
+  process.exit(1);
+}
+
+// ── Load and validate export file ─────────────────────────────────────────
+
+let exportData: SweetfolioAiExport;
+try {
+  const raw = readFileSync(filePath, 'utf-8');
+  exportData = JSON.parse(raw) as SweetfolioAiExport;
+} catch (err) {
+  console.error(`Error: Could not read or parse file "${filePath}":`, err);
+  process.exit(1);
+}
+
+if (exportData.format !== 'sweetfolio-ai') {
+  console.error(
+    `Error: Invalid export format. Expected "sweetfolio-ai", got "${exportData.format}".`
+  );
+  process.exit(1);
+}
+
+// ── Type definitions ───────────────────────────────────────────────────────
+
+interface Transaction {
+  id: string;
+  date: string;
+  type: string;
+  shares?: number;
+  price?: number;
+  amount: number;
+  currency: string;
+  [key: string]: unknown;
+}
+
+interface Portfolio {
+  id: string;
+  name: string;
+  currency?: string;
+  transactions?: Transaction[];
+  [key: string]: unknown;
+}
+
+interface AssetPrice {
+  date: string;
+  price: number;
+  [key: string]: unknown;
+}
+
+interface Asset {
+  id: string;
+  name: string;
+  symbol?: string;
+  isin?: string;
+  currency?: string;
+  prices?: AssetPrice[];
+  [key: string]: unknown;
+}
+
+interface SweetfolioAiExport {
+  format: string;
+  exportedAt?: string;
+  portfolios?: Portfolio[];
+  assets?: Asset[];
+  [key: string]: unknown;
+}
+
+// ── Helper: strip large arrays for summary views ───────────────────────────
+
+function portfolioSummary(p: Portfolio) {
+  const { transactions, ...meta } = p;
+  return {
+    ...meta,
+    transactionCount: transactions?.length ?? 0,
+  };
+}
+
+function assetSummary(a: Asset) {
+  const { prices, ...meta } = a;
+  return {
+    ...meta,
+    priceHistoryCount: prices?.length ?? 0,
+  };
+}
+
+// ── MCP Server setup ───────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: 'sweetfolio', version: '1.0.0' },
+  { capabilities: { tools: {} } }
+);
+
+// List tools
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'get_portfolios',
+      description:
+        'Returns all portfolios with metadata and transaction count (no raw transactions).',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: 'get_transactions',
+      description: 'Returns all transactions for a specific portfolio by its ID.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          portfolioId: {
+            type: 'string',
+            description: 'The ID of the portfolio whose transactions to retrieve.',
+          },
+        },
+        required: ['portfolioId'],
+      },
+    },
+    {
+      name: 'get_assets',
+      description:
+        'Returns all assets with metadata and price history count (no raw price history).',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: 'get_asset_prices',
+      description: 'Returns the full price history for a specific asset by its ID.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          assetId: {
+            type: 'string',
+            description: 'The ID of the asset whose price history to retrieve.',
+          },
+        },
+        required: ['assetId'],
+      },
+    },
+  ],
+}));
+
+// Call tools
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  switch (name) {
+    case 'get_portfolios': {
+      const portfolios = (exportData.portfolios ?? []).map(portfolioSummary);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(portfolios, null, 2),
+          },
+        ],
+      };
+    }
+
+    case 'get_transactions': {
+      const portfolioId = (args as Record<string, string>)?.portfolioId;
+      if (!portfolioId) {
+        return {
+          content: [{ type: 'text', text: 'Error: portfolioId is required.' }],
+          isError: true,
+        };
+      }
+      const portfolio = (exportData.portfolios ?? []).find((p) => p.id === portfolioId);
+      if (!portfolio) {
+        return {
+          content: [
+            { type: 'text', text: `Error: No portfolio found with ID "${portfolioId}".` },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(portfolio.transactions ?? [], null, 2),
+          },
+        ],
+      };
+    }
+
+    case 'get_assets': {
+      const assets = (exportData.assets ?? []).map(assetSummary);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(assets, null, 2),
+          },
+        ],
+      };
+    }
+
+    case 'get_asset_prices': {
+      const assetId = (args as Record<string, string>)?.assetId;
+      if (!assetId) {
+        return {
+          content: [{ type: 'text', text: 'Error: assetId is required.' }],
+          isError: true,
+        };
+      }
+      const asset = (exportData.assets ?? []).find((a) => a.id === assetId);
+      if (!asset) {
+        return {
+          content: [{ type: 'text', text: `Error: No asset found with ID "${assetId}".` }],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(asset.prices ?? [], null, 2),
+          },
+        ],
+      };
+    }
+
+    default:
+      return {
+        content: [{ type: 'text', text: `Error: Unknown tool "${name}".` }],
+        isError: true,
+      };
+  }
+});
+
+// ── Start server ───────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/tools/mcp-server/tsconfig.json
+++ b/tools/mcp-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Add `sweetfolio-ai` export format — a self-describing JSON with manifest and embedded type descriptions
- Transactions are embedded inside portfolio objects for easy AI consumption
- Asset summaries include `latestPrice` and `latestPriceDate` fields
- Add Settings button "Download AI Export" that generates `sweetfolio-ai-export.json`
- Add local MCP server (`tools/mcp-server/`) that reads the export file and exposes portfolio data as tools

## Why file-based MCP?

Sweetfolio is a fully client-side SPA (IndexedDB only, no backend). A live MCP connection to the browser is not possible — the browser cannot expose an MCP server endpoint. The file-based approach bridges this gap: export once, run MCP server against the file.

## MCP Server Tools

| Tool | Description |
|------|-------------|
| `get_portfolios` | List portfolios with transaction counts |
| `get_transactions` | Get all transactions for a portfolio |
| `get_assets` | List assets with latest prices |
| `get_asset_prices` | Get full price history for an asset |

## Setup

```bash
cd tools/mcp-server
npm install && npm run build
# Add to .claude/settings.json:
# { "mcpServers": { "sweetfolio": { "command": "node", "args": ["dist/index.js", "/path/to/export.json"] } } }
```

## Test plan

- [x] Unit tests: `npm run test` — all pass (7 new tests for ai-export)
- [ ] Manual: Export AI format from Settings, verify JSON structure matches manifest
- [ ] Manual: Run MCP server with export file, verify tools respond correctly

🤖 Generated with Claude Code