### PR TITLE
fix(onvista): use eod_history endpoint for historical price fetching

### DIFF
--- a/src/lib/fetchers/onvista.test.ts
+++ b/src/lib/fetchers/onvista.test.ts
@@ -153,6 +153,23 @@ describe('getChartHistory', () => {
     expect(prices[0].date < prices[1].date).toBe(true);
   });
 
+  it('requests the eod_history endpoint with range=MAX', async () => {
+    const spy = mockFetch([
+      { ok: true, json: () => ({ datetimeLast: [1704067200000], last: [100.0] }) },
+    ]);
+
+    await getChartHistory('FUND', '12345', 99999);
+
+    const url = spy.mock.calls[0][0] as string;
+    // Onvista retired chart_history; we must hit eod_history with range/startDate
+    expect(url).toContain('/instruments/FUND/12345/eod_history');
+    expect(url).toContain('idNotation=99999');
+    expect(url).toContain('range=MAX');
+    expect(url).toContain('startDate=');
+    expect(url).not.toContain('chart_history');
+    expect(url).not.toContain('resolution=');
+  });
+
   it('deduplicates by date', async () => {
     mockFetch([
       {

--- a/src/lib/fetchers/onvista.ts
+++ b/src/lib/fetchers/onvista.ts
@@ -7,7 +7,7 @@
  * Flow:
  * 1. Search by ISIN or WKN to find the instrument
  * 2. Get snapshot for the instrument to obtain idNotation and metadata
- * 3. Fetch chart history using idNotation for daily resolution
+ * 3. Fetch end-of-day history using idNotation for daily prices
  */
 
 import type { PricePoint, AssetClassification } from '$lib/types';
@@ -56,7 +56,7 @@ interface SnapshotResponse {
   wkn?: string;
 }
 
-interface ChartHistoryResponse {
+interface EodHistoryResponse {
   datetimeLast: number[];
   last: number[];
 }
@@ -175,23 +175,30 @@ export async function getSnapshot(
 }
 
 /**
- * Fetch daily chart history for an instrument.
- * Defaults to fetching all available data (from 2000-01-01 to today).
+ * Fetch daily end-of-day price history for an instrument.
+ *
+ * Uses Onvista's `eod_history` endpoint. Onvista retired the previously used
+ * `chart_history` endpoint (`resolution=1D&startDate=…&endDate=…`), which broke
+ * historical price fetching by ISIN/WKN. The `eod_history` endpoint takes a
+ * `range` (here `MAX` for the full available history) together with a `startDate`
+ * floor. The JSON response shape (parallel `datetimeLast` / `last` arrays) is
+ * unchanged between the two endpoints.
+ *
+ * Defaults to fetching all available data (from 2000-01-01, a floor well before
+ * any tradable instrument's inception).
  */
 export async function getChartHistory(
   entityType: string,
   entityValue: string,
   idNotation: number,
   startDate?: Date,
-  endDate?: Date,
 ): Promise<PricePoint[]> {
   const start = formatDate(startDate ?? new Date(2000, 0, 1));
-  const end = formatDate(endDate ?? new Date());
   const url =
-    `${BASE_URL}/instruments/${encodeURIComponent(entityType)}/${encodeURIComponent(entityValue)}/chart_history` +
-    `?idNotation=${idNotation}&resolution=1D&startDate=${start}&endDate=${end}`;
+    `${BASE_URL}/instruments/${encodeURIComponent(entityType)}/${encodeURIComponent(entityValue)}/eod_history` +
+    `?idNotation=${idNotation}&range=MAX&startDate=${start}`;
 
-  const data = await fetchJSON<ChartHistoryResponse>(url);
+  const data = await fetchJSON<EodHistoryResponse>(url);
 
   if (!data.datetimeLast || !data.last || data.datetimeLast.length !== data.last.length) {
     return [];


### PR DESCRIPTION
## Problem

Fetching ETF (and other) price data by ISIN/WKN stopped working in the live app. The Onvista fetcher's last step (`getChartHistory`) requested the **`chart_history`** endpoint:

```
/instruments/{type}/{id}/chart_history?idNotation=…&resolution=1D&startDate=…&endDate=…
```

Onvista has **retired `chart_history`**. The onvista.de website itself and every maintained third-party client (Portfolio Performance, grafioschtrader, vistafetch, pyOnvista-based tools, the "OnVistaJsonStockUrlFinder" browser extension, …) now use the **`eod_history`** endpoint instead. Since the request 404'd/failed, `getChartHistory` returned an empty array and `fetchPriceData` reported *"No price data available"*.

### Why the fallbacks didn't help

For an ISIN/WKN the only registered fallback after Onvista is Alpha Vantage, which (a) is skipped entirely unless the user has configured an API key, and (b) resolves symbols via `SYMBOL_SEARCH`, which generally doesn't accept ISINs. So in practice Onvista is the sole working ISIN source — once its history endpoint broke, there was no effective fallback. Restoring Onvista is therefore the actual fix.

## Fix

Switch `getChartHistory` to the `eod_history` endpoint:

```
/instruments/{type}/{id}/eod_history?idNotation=…&range=MAX&startDate=…
```

- `range=MAX` requests the full available history (replacing `resolution=1D` + `endDate`).
- `startDate` is kept as a floor (default `2000-01-01`).
- The JSON response shape is **identical** between the two endpoints (parallel `datetimeLast` / `last` arrays), so the parsing logic is unchanged.

This also restores the crypto-ticker path, which shares `getChartHistory`.

## Tests

- All existing tests still pass (`vitest run`: 328 passed).
- Added a regression test asserting the request now targets `eod_history` with `range=MAX` and no longer uses `chart_history` / `resolution`.

## Note

I couldn't reach `api.onvista.de` from the sandbox (host not allow-listed) to do a live end-to-end check, so the diagnosis is based on the current onvista.de website behaviour and multiple maintained reference implementations. Worth a quick manual verification with a real ISIN once deployed.

https://claude.ai/code/session_01FbRvZKixnV5KZaCPMLDqUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbRvZKixnV5KZaCPMLDqUa)_